### PR TITLE
[TEST] ZooKeeper 분산 락 수강신청 nGrinder 부하 테스트 스크립트 추가

### DIFF
--- a/docs/scripts/ngrinder/13ZooKeeperWarmUpTest.groovy
+++ b/docs/scripts/ngrinder/13ZooKeeperWarmUpTest.groovy
@@ -1,0 +1,146 @@
+import static net.grinder.script.Grinder.grinder
+import static org.junit.Assert.*
+import static org.hamcrest.Matchers.*
+import net.grinder.script.GTest
+import net.grinder.scriptengine.groovy.junit.GrinderRunner
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
+import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ngrinder.http.HTTPRequest
+import org.ngrinder.http.HTTPRequestControl
+import org.ngrinder.http.HTTPResponse
+import java.util.Collections
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ThreadLocalRandom
+
+@RunWith(GrinderRunner)
+class ZooKeeperWarmUpTest {
+
+    public static GTest test
+    public static HTTPRequest request
+    public static Map<String, String> headers = [:]
+
+    // 학생 ID 저장을 위한 큐
+    public static ConcurrentLinkedQueue<Integer> studentIdQueue = new ConcurrentLinkedQueue<>()
+
+    // 테스트 환경 설정
+    public static final String TARGET_IP = "host.docker.internal"
+    public static final String TARGET_PORT = "8080"
+
+    // 실험 파라미터 설정 (테스트 시간: 10초)
+    public static final int TOTAL_USERS = 200
+
+    public static final int TEST_DURATION_SECONDS = 10
+
+    // 테스트 전략 선택
+    public static final String STRATEGY = "zookeeper-lock"
+
+    public static String targetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/enrollments/${STRATEGY}"
+    public static String resetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/benchmarks/reset"
+
+    @BeforeProcess
+    public static void beforeProcess() {
+
+        // 커넥션 타임아웃 10초 설정
+        HTTPRequestControl.setConnectionTimeout(10000)
+
+        test = new GTest(1, "Enrollment Burst Warm-Up Test - ${STRATEGY}")
+        request = new HTTPRequest()
+        headers.put("Content-Type", "application/json")
+
+        long beforeStartTime = System.currentTimeMillis()   // 진입 시간 기록
+
+        // [DB 데이터 클렌징] 프로세스 0에서만 초기화
+        if (grinder.processNumber == 0) {
+
+            grinder.logger.info(">>> [DB 초기화] 테스트 전략 세팅 중: ${STRATEGY}")
+
+            try {
+
+                HTTPResponse resetResponse = request.POST(resetUrl, "".getBytes(), headers)
+
+                if (resetResponse.statusCode == 200) {
+                    grinder.logger.info(">>> [DB 초기화 완료] 응답: ${resetResponse.bodyText}")
+                } else {
+                    grinder.logger.error(">>> [DB 초기화 실패] HTTP 상태 코드: ${resetResponse.statusCode}")
+                }
+            } catch (Exception e) {
+                grinder.logger.error(">>> [DB 초기화 에러] 원인: ${e.message}")
+            }
+        }
+
+        // 모든 프로세스가 각자 소모한 시간 계산
+        long elapsed = System.currentTimeMillis() - beforeStartTime
+
+        // 목표 대기 시간(3초)에서 소모한 시간(DB 초기화 등)을 뺀 만큼만 정확히 마저 대기
+        long waitTime = 3000 - elapsed
+
+        if (waitTime > 0) {
+            grinder.logger.info(">>> [대기] 프로세스 ${grinder.processNumber} : 완벽한 동시 출발을 위해 ${waitTime}ms 대기 중...")
+            grinder.sleep(waitTime, 0)
+        }
+
+        test.record(request)
+
+        // 프로세스별 학생 ID 할당
+        int totalProcesses = grinder.getProperties().getInt("grinder.processes", 1)
+        int usersPerProcess = TOTAL_USERS / totalProcesses
+
+        int startId = (grinder.processNumber * usersPerProcess) + 1
+        int endId = (grinder.processNumber + 1) * usersPerProcess
+
+        List<Integer> studentIds = (startId..endId).toList()
+        Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
+
+        studentIdQueue.clear()
+        studentIdQueue.addAll(studentIds)
+
+        grinder.logger.info(">>> [데이터 준비 완료] 프로세스 {} 학생 ID {} ~ {} (총 {}명) 큐 적재 완료",
+            grinder.processNumber, startId, endId, studentIds.size())
+    }
+
+    @Test
+    public void testEnrollmentBurst() {
+
+        // 지수 감쇠형 버스트 시뮬레이션
+        double u = ThreadLocalRandom.current().nextDouble()
+        double lambdaShape = 1.0
+        double maxTime = (double) TEST_DURATION_SECONDS
+
+        // 역함수 샘플링 공식을 통한 시간 계산
+        double timeInSec = -Math.log(1 - u * (1 - Math.exp(-lambdaShape * maxTime))) / lambdaShape
+        long randomDelay = (long) (timeInSec * 1000)
+
+        // 계산된 시간만큼 대기 후 발사
+        grinder.sleep(randomDelay, 0)
+
+        // 큐에서 무작위 학생 ID 추출
+        Integer studentId = studentIdQueue.poll()
+
+        if (studentId == null) {
+            grinder.logger.warn(">>> [테스트 경고] 이 프로세스에 할당된 학생 ID가 모두 소진되었습니다.")
+            return
+        }
+
+        long courseId = 1L
+
+        String payload = String.format("{\"studentId\": %d, \"courseId\": %d}", studentId, courseId)
+
+        // API POST 요청
+        HTTPResponse response = request.POST(targetUrl, payload.getBytes(), headers)
+
+        int statusCode = response.statusCode
+
+        // 검증 로직
+        if (statusCode == 200 || statusCode == 201) {
+            assertThat(statusCode, is(anyOf(equalTo(200), equalTo(201))))
+        } else if (statusCode == 400 || statusCode == 409) {
+            grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
+        } else {
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            fail("동시성 제어 실패: HTTP ${statusCode}")
+        }
+    }
+}

--- a/docs/scripts/ngrinder/13ZooKeeperWarmUpTest.groovy
+++ b/docs/scripts/ngrinder/13ZooKeeperWarmUpTest.groovy
@@ -4,8 +4,6 @@ import static org.hamcrest.Matchers.*
 import net.grinder.script.GTest
 import net.grinder.scriptengine.groovy.junit.GrinderRunner
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
-import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ngrinder.http.HTTPRequest
@@ -139,7 +137,7 @@ class ZooKeeperWarmUpTest {
         } else if (statusCode == 400 || statusCode == 409) {
             grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
         } else {
-            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]")
             fail("동시성 제어 실패: HTTP ${statusCode}")
         }
     }

--- a/docs/scripts/ngrinder/14ZooKeeper500Test.groovy
+++ b/docs/scripts/ngrinder/14ZooKeeper500Test.groovy
@@ -5,7 +5,6 @@ import net.grinder.script.GTest
 import net.grinder.scriptengine.groovy.junit.GrinderRunner
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
 import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ngrinder.http.HTTPRequest
@@ -108,7 +107,9 @@ class ZooKeeper500Test {
         int usersPerProcess = TOTAL_USERS / totalProcesses
 
         int startId = (grinder.processNumber * usersPerProcess) + 1
-        int endId = (grinder.processNumber + 1) * usersPerProcess
+        int endId = (grinder.processNumber == totalProcesses - 1)
+            ? TOTAL_USERS
+            : (grinder.processNumber + 1) * usersPerProcess
 
         List<Integer> studentIds = (startId..endId).toList()
         Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
@@ -164,7 +165,7 @@ class ZooKeeper500Test {
         } else if (statusCode == 400 || statusCode == 409) {
             grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
         } else {
-            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]")
             fail("동시성 제어 실패: HTTP ${statusCode}")
         }
     }
@@ -182,6 +183,7 @@ class ZooKeeper500Test {
             // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
             String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
             File resultFile = new File(fileName)
+            resultFile.parentFile.mkdirs()
             
             // 파일에 프로세스별 배열 기록
             resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")

--- a/docs/scripts/ngrinder/14ZooKeeper500Test.groovy
+++ b/docs/scripts/ngrinder/14ZooKeeper500Test.groovy
@@ -1,0 +1,193 @@
+import static net.grinder.script.Grinder.grinder
+import static org.junit.Assert.*
+import static org.hamcrest.Matchers.*
+import net.grinder.script.GTest
+import net.grinder.scriptengine.groovy.junit.GrinderRunner
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
+import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ngrinder.http.HTTPRequest
+import org.ngrinder.http.HTTPRequestControl
+import org.ngrinder.http.HTTPResponse
+import java.util.Collections
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+
+@RunWith(GrinderRunner)
+class ZooKeeper500Test {
+
+    public static GTest test
+    public static HTTPRequest request
+    public static Map<String, String> headers = [:]
+
+    // 학생 ID 저장을 위한 큐
+    public static ConcurrentLinkedQueue<Integer> studentIdQueue = new ConcurrentLinkedQueue<>()
+
+    // 실제 유입 카운트를 기록할 Thread-safe 배열 (넉넉하게 15초로 설정)
+    public static AtomicIntegerArray actualArrivals = new AtomicIntegerArray(15)
+
+    // 테스트 시작 시간을 기록할 변수
+    public static String testStartTime
+
+    // 테스트 환경 설정
+    public static final String TARGET_IP = "host.docker.internal"
+    public static final String TARGET_PORT = "8080"
+
+    // 실험 파라미터 설정 (테스트 시간: 10초)
+    public static final int TOTAL_USERS = 500
+
+    public static final int TEST_DURATION_SECONDS = 10
+
+    // 테스트 전략 선택
+    public static final String STRATEGY = "zookeeper-lock"
+
+    public static String targetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/enrollments/${STRATEGY}"
+    public static String resetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/benchmarks/reset"
+
+    @BeforeProcess
+    public static void beforeProcess() {
+
+        // 커넥션 타임아웃 10초 설정
+        HTTPRequestControl.setConnectionTimeout(10000)
+
+        test = new GTest(1, "Enrollment Burst Test - ${STRATEGY}")
+        request = new HTTPRequest()
+        headers.put("Content-Type", "application/json")
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmm")
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"))
+        testStartTime = sdf.format(new Date())
+
+        long beforeStartTime = System.currentTimeMillis()   // 진입 시간 기록
+
+        // [DB 데이터 클렌징] 프로세스 0에서만 초기화
+        if (grinder.processNumber == 0) {
+
+            grinder.logger.info(">>> [DB 초기화] 테스트 전략 세팅 중: ${STRATEGY}")
+
+            try {
+
+                HTTPResponse resetResponse = request.POST(resetUrl, "".getBytes(), headers)
+
+                if (resetResponse.statusCode == 200) {
+                    grinder.logger.info(">>> [DB 초기화 완료] 응답: ${resetResponse.bodyText}")
+                } else {
+                    grinder.logger.error(">>> [DB 초기화 실패] HTTP 상태 코드: ${resetResponse.statusCode}")
+                }
+            } catch (Exception e) {
+                grinder.logger.error(">>> [DB 초기화 에러] 원인: ${e.message}")
+            }
+        }
+
+        // 모든 프로세스가 각자 소모한 시간 계산
+        long elapsed = System.currentTimeMillis() - beforeStartTime
+
+        // 목표 대기 시간(3초)에서 소모한 시간(DB 초기화 등)을 뺀 만큼만 정확히 마저 대기
+        long waitTime = 3000 - elapsed
+
+        if (waitTime > 0) {
+            grinder.logger.info(">>> [대기] 프로세스 ${grinder.processNumber} : 완벽한 동시 출발을 위해 ${waitTime}ms 대기 중...")
+            grinder.sleep(waitTime, 0)
+        }
+
+        // 매 프로세스 시작 시 실제 유입 카운트 배열 초기화
+        for (int i = 0; i < actualArrivals.length(); i++) {
+            actualArrivals.set(i, 0)
+        }
+
+        test.record(request)
+
+        // 프로세스별 학생 ID 할당
+        int totalProcesses = grinder.getProperties().getInt("grinder.processes", 1)
+        int usersPerProcess = TOTAL_USERS / totalProcesses
+
+        int startId = (grinder.processNumber * usersPerProcess) + 1
+        int endId = (grinder.processNumber + 1) * usersPerProcess
+
+        List<Integer> studentIds = (startId..endId).toList()
+        Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
+
+        studentIdQueue.clear()
+        studentIdQueue.addAll(studentIds)
+
+        grinder.logger.info(">>> [데이터 준비 완료] 프로세스 {} 학생 ID {} ~ {} (총 {}명) 큐 적재 완료",
+            grinder.processNumber, startId, endId, studentIds.size())
+    }
+
+    @Test
+    public void testEnrollmentBurst() {
+
+        // 지수 감쇠형 버스트 시뮬레이션
+        double u = ThreadLocalRandom.current().nextDouble()
+        double lambdaShape = 1.0
+        double maxTime = (double) TEST_DURATION_SECONDS
+
+        // 역함수 샘플링 공식을 통한 시간 계산
+        double timeInSec = -Math.log(1 - u * (1 - Math.exp(-lambdaShape * maxTime))) / lambdaShape
+        long randomDelay = (long) (timeInSec * 1000)
+
+        // [실제 유입 기록] 딜레이 시간을 초 단위로 환산하여 카운트 1 증가
+        int fireSecond = (int) (randomDelay / 1000)
+        if (fireSecond >= 0 && fireSecond < actualArrivals.length()) {
+            actualArrivals.incrementAndGet(fireSecond)
+        }
+
+        // 계산된 시간만큼 대기 후 발사
+        grinder.sleep(randomDelay, 0)
+
+        // 큐에서 무작위 학생 ID 추출
+        Integer studentId = studentIdQueue.poll()
+
+        if (studentId == null) {
+            grinder.logger.warn(">>> [테스트 경고] 이 프로세스에 할당된 학생 ID가 모두 소진되었습니다.")
+            return
+        }
+
+        long courseId = 1L
+
+        String payload = String.format("{\"studentId\": %d, \"courseId\": %d}", studentId, courseId)
+
+        // API POST 요청
+        HTTPResponse response = request.POST(targetUrl, payload.getBytes(), headers)
+
+        int statusCode = response.statusCode
+
+        // 검증 로직
+        if (statusCode == 200 || statusCode == 201) {
+            assertThat(statusCode, is(anyOf(equalTo(200), equalTo(201))))
+        } else if (statusCode == 400 || statusCode == 409) {
+            grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
+        } else {
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            fail("동시성 제어 실패: HTTP ${statusCode}")
+        }
+    }
+
+    @AfterProcess
+    public static void afterProcess() {
+
+        // 테스트 종료 시 10초간의 실제 유입량을 리스트로 변환하여 출력
+        List<Integer> actualList = []
+        for (int i = 0; i < TEST_DURATION_SECONDS; i++) {
+            actualList.add(actualArrivals.get(i))
+        }
+
+        try {
+            // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
+            String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
+            File resultFile = new File(fileName)
+            
+            // 파일에 프로세스별 배열 기록
+            resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")
+            
+        } catch (Exception e) {
+            // 무시
+        }
+    }
+}

--- a/docs/scripts/ngrinder/15ZooKeeper800Test.groovy
+++ b/docs/scripts/ngrinder/15ZooKeeper800Test.groovy
@@ -1,0 +1,193 @@
+import static net.grinder.script.Grinder.grinder
+import static org.junit.Assert.*
+import static org.hamcrest.Matchers.*
+import net.grinder.script.GTest
+import net.grinder.scriptengine.groovy.junit.GrinderRunner
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
+import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ngrinder.http.HTTPRequest
+import org.ngrinder.http.HTTPRequestControl
+import org.ngrinder.http.HTTPResponse
+import java.util.Collections
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+
+@RunWith(GrinderRunner)
+class ZooKeeper800Test {
+
+    public static GTest test
+    public static HTTPRequest request
+    public static Map<String, String> headers = [:]
+
+    // 학생 ID 저장을 위한 큐
+    public static ConcurrentLinkedQueue<Integer> studentIdQueue = new ConcurrentLinkedQueue<>()
+
+    // 실제 유입 카운트를 기록할 Thread-safe 배열 (넉넉하게 15초로 설정)
+    public static AtomicIntegerArray actualArrivals = new AtomicIntegerArray(15)
+
+    // 테스트 시작 시간을 기록할 변수
+    public static String testStartTime
+
+    // 테스트 환경 설정
+    public static final String TARGET_IP = "host.docker.internal"
+    public static final String TARGET_PORT = "8080"
+
+    // 실험 파라미터 설정 (테스트 시간: 10초)
+    public static final int TOTAL_USERS = 800
+
+    public static final int TEST_DURATION_SECONDS = 10
+
+    // 테스트 전략 선택
+    public static final String STRATEGY = "zookeeper-lock"
+
+    public static String targetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/enrollments/${STRATEGY}"
+    public static String resetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/benchmarks/reset"
+
+    @BeforeProcess
+    public static void beforeProcess() {
+
+        // 커넥션 타임아웃 10초 설정
+        HTTPRequestControl.setConnectionTimeout(10000)
+
+        test = new GTest(1, "Enrollment Burst Test - ${STRATEGY}")
+        request = new HTTPRequest()
+        headers.put("Content-Type", "application/json")
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmm")
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"))
+        testStartTime = sdf.format(new Date())
+
+        long beforeStartTime = System.currentTimeMillis()   // 진입 시간 기록
+
+        // [DB 데이터 클렌징] 프로세스 0에서만 초기화
+        if (grinder.processNumber == 0) {
+
+            grinder.logger.info(">>> [DB 초기화] 테스트 전략 세팅 중: ${STRATEGY}")
+
+            try {
+
+                HTTPResponse resetResponse = request.POST(resetUrl, "".getBytes(), headers)
+
+                if (resetResponse.statusCode == 200) {
+                    grinder.logger.info(">>> [DB 초기화 완료] 응답: ${resetResponse.bodyText}")
+                } else {
+                    grinder.logger.error(">>> [DB 초기화 실패] HTTP 상태 코드: ${resetResponse.statusCode}")
+                }
+            } catch (Exception e) {
+                grinder.logger.error(">>> [DB 초기화 에러] 원인: ${e.message}")
+            }
+        }
+
+        // 모든 프로세스가 각자 소모한 시간 계산
+        long elapsed = System.currentTimeMillis() - beforeStartTime
+
+        // 목표 대기 시간(3초)에서 소모한 시간(DB 초기화 등)을 뺀 만큼만 정확히 마저 대기
+        long waitTime = 3000 - elapsed
+
+        if (waitTime > 0) {
+            grinder.logger.info(">>> [대기] 프로세스 ${grinder.processNumber} : 완벽한 동시 출발을 위해 ${waitTime}ms 대기 중...")
+            grinder.sleep(waitTime, 0)
+        }
+
+        // 매 프로세스 시작 시 실제 유입 카운트 배열 초기화
+        for (int i = 0; i < actualArrivals.length(); i++) {
+            actualArrivals.set(i, 0)
+        }
+
+        test.record(request)
+
+        // 프로세스별 학생 ID 할당
+        int totalProcesses = grinder.getProperties().getInt("grinder.processes", 1)
+        int usersPerProcess = TOTAL_USERS / totalProcesses
+
+        int startId = (grinder.processNumber * usersPerProcess) + 1
+        int endId = (grinder.processNumber + 1) * usersPerProcess
+
+        List<Integer> studentIds = (startId..endId).toList()
+        Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
+
+        studentIdQueue.clear()
+        studentIdQueue.addAll(studentIds)
+
+        grinder.logger.info(">>> [데이터 준비 완료] 프로세스 {} 학생 ID {} ~ {} (총 {}명) 큐 적재 완료",
+            grinder.processNumber, startId, endId, studentIds.size())
+    }
+
+    @Test
+    public void testEnrollmentBurst() {
+
+        // 지수 감쇠형 버스트 시뮬레이션
+        double u = ThreadLocalRandom.current().nextDouble()
+        double lambdaShape = 1.0
+        double maxTime = (double) TEST_DURATION_SECONDS
+
+        // 역함수 샘플링 공식을 통한 시간 계산
+        double timeInSec = -Math.log(1 - u * (1 - Math.exp(-lambdaShape * maxTime))) / lambdaShape
+        long randomDelay = (long) (timeInSec * 1000)
+
+        // [실제 유입 기록] 딜레이 시간을 초 단위로 환산하여 카운트 1 증가
+        int fireSecond = (int) (randomDelay / 1000)
+        if (fireSecond >= 0 && fireSecond < actualArrivals.length()) {
+            actualArrivals.incrementAndGet(fireSecond)
+        }
+
+        // 계산된 시간만큼 대기 후 발사
+        grinder.sleep(randomDelay, 0)
+
+        // 큐에서 무작위 학생 ID 추출
+        Integer studentId = studentIdQueue.poll()
+
+        if (studentId == null) {
+            grinder.logger.warn(">>> [테스트 경고] 이 프로세스에 할당된 학생 ID가 모두 소진되었습니다.")
+            return
+        }
+
+        long courseId = 1L
+
+        String payload = String.format("{\"studentId\": %d, \"courseId\": %d}", studentId, courseId)
+
+        // API POST 요청
+        HTTPResponse response = request.POST(targetUrl, payload.getBytes(), headers)
+
+        int statusCode = response.statusCode
+
+        // 검증 로직
+        if (statusCode == 200 || statusCode == 201) {
+            assertThat(statusCode, is(anyOf(equalTo(200), equalTo(201))))
+        } else if (statusCode == 400 || statusCode == 409) {
+            grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
+        } else {
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            fail("동시성 제어 실패: HTTP ${statusCode}")
+        }
+    }
+
+    @AfterProcess
+    public static void afterProcess() {
+
+        // 테스트 종료 시 10초간의 실제 유입량을 리스트로 변환하여 출력
+        List<Integer> actualList = []
+        for (int i = 0; i < TEST_DURATION_SECONDS; i++) {
+            actualList.add(actualArrivals.get(i))
+        }
+
+        try {
+            // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
+            String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
+            File resultFile = new File(fileName)
+            
+            // 파일에 프로세스별 배열 기록
+            resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")
+            
+        } catch (Exception e) {
+            // 무시
+        }
+    }
+}

--- a/docs/scripts/ngrinder/15ZooKeeper800Test.groovy
+++ b/docs/scripts/ngrinder/15ZooKeeper800Test.groovy
@@ -5,7 +5,6 @@ import net.grinder.script.GTest
 import net.grinder.scriptengine.groovy.junit.GrinderRunner
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
 import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ngrinder.http.HTTPRequest
@@ -108,7 +107,9 @@ class ZooKeeper800Test {
         int usersPerProcess = TOTAL_USERS / totalProcesses
 
         int startId = (grinder.processNumber * usersPerProcess) + 1
-        int endId = (grinder.processNumber + 1) * usersPerProcess
+        int endId = (grinder.processNumber == totalProcesses - 1)
+            ? TOTAL_USERS
+            : (grinder.processNumber + 1) * usersPerProcess
 
         List<Integer> studentIds = (startId..endId).toList()
         Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
@@ -164,7 +165,7 @@ class ZooKeeper800Test {
         } else if (statusCode == 400 || statusCode == 409) {
             grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
         } else {
-            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]")
             fail("동시성 제어 실패: HTTP ${statusCode}")
         }
     }
@@ -182,6 +183,7 @@ class ZooKeeper800Test {
             // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
             String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
             File resultFile = new File(fileName)
+            resultFile.parentFile.mkdirs()
             
             // 파일에 프로세스별 배열 기록
             resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")

--- a/docs/scripts/ngrinder/16ZooKeeper1000Test.groovy
+++ b/docs/scripts/ngrinder/16ZooKeeper1000Test.groovy
@@ -5,7 +5,6 @@ import net.grinder.script.GTest
 import net.grinder.scriptengine.groovy.junit.GrinderRunner
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
 import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ngrinder.http.HTTPRequest
@@ -108,7 +107,9 @@ class ZooKeeper1000Test {
         int usersPerProcess = TOTAL_USERS / totalProcesses
 
         int startId = (grinder.processNumber * usersPerProcess) + 1
-        int endId = (grinder.processNumber + 1) * usersPerProcess
+        int endId = (grinder.processNumber == totalProcesses - 1)
+            ? TOTAL_USERS
+            : (grinder.processNumber + 1) * usersPerProcess
 
         List<Integer> studentIds = (startId..endId).toList()
         Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
@@ -164,7 +165,7 @@ class ZooKeeper1000Test {
         } else if (statusCode == 400 || statusCode == 409) {
             grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
         } else {
-            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]")
             fail("동시성 제어 실패: HTTP ${statusCode}")
         }
     }
@@ -182,6 +183,7 @@ class ZooKeeper1000Test {
             // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
             String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
             File resultFile = new File(fileName)
+            resultFile.parentFile.mkdirs()
             
             // 파일에 프로세스별 배열 기록
             resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")

--- a/docs/scripts/ngrinder/16ZooKeeper1000Test.groovy
+++ b/docs/scripts/ngrinder/16ZooKeeper1000Test.groovy
@@ -1,0 +1,193 @@
+import static net.grinder.script.Grinder.grinder
+import static org.junit.Assert.*
+import static org.hamcrest.Matchers.*
+import net.grinder.script.GTest
+import net.grinder.scriptengine.groovy.junit.GrinderRunner
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
+import net.grinder.scriptengine.groovy.junit.annotation.AfterProcess
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ngrinder.http.HTTPRequest
+import org.ngrinder.http.HTTPRequestControl
+import org.ngrinder.http.HTTPResponse
+import java.util.Collections
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicIntegerArray
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+
+@RunWith(GrinderRunner)
+class ZooKeeper1000Test {
+
+    public static GTest test
+    public static HTTPRequest request
+    public static Map<String, String> headers = [:]
+
+    // 학생 ID 저장을 위한 큐
+    public static ConcurrentLinkedQueue<Integer> studentIdQueue = new ConcurrentLinkedQueue<>()
+
+    // 실제 유입 카운트를 기록할 Thread-safe 배열 (넉넉하게 15초로 설정)
+    public static AtomicIntegerArray actualArrivals = new AtomicIntegerArray(15)
+
+    // 테스트 시작 시간을 기록할 변수
+    public static String testStartTime
+
+    // 테스트 환경 설정
+    public static final String TARGET_IP = "host.docker.internal"
+    public static final String TARGET_PORT = "8080"
+
+    // 실험 파라미터 설정 (테스트 시간: 10초)
+    public static final int TOTAL_USERS = 1000
+
+    public static final int TEST_DURATION_SECONDS = 10
+
+    // 테스트 전략 선택
+    public static final String STRATEGY = "zookeeper-lock"
+
+    public static String targetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/enrollments/${STRATEGY}"
+    public static String resetUrl = "http://${TARGET_IP}:${TARGET_PORT}/v1/benchmarks/reset"
+
+    @BeforeProcess
+    public static void beforeProcess() {
+
+        // 커넥션 타임아웃 10초 설정
+        HTTPRequestControl.setConnectionTimeout(10000)
+
+        test = new GTest(1, "Enrollment Burst Test - ${STRATEGY}")
+        request = new HTTPRequest()
+        headers.put("Content-Type", "application/json")
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmm")
+        sdf.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"))
+        testStartTime = sdf.format(new Date())
+
+        long beforeStartTime = System.currentTimeMillis()   // 진입 시간 기록
+
+        // [DB 데이터 클렌징] 프로세스 0에서만 초기화
+        if (grinder.processNumber == 0) {
+
+            grinder.logger.info(">>> [DB 초기화] 테스트 전략 세팅 중: ${STRATEGY}")
+
+            try {
+
+                HTTPResponse resetResponse = request.POST(resetUrl, "".getBytes(), headers)
+
+                if (resetResponse.statusCode == 200) {
+                    grinder.logger.info(">>> [DB 초기화 완료] 응답: ${resetResponse.bodyText}")
+                } else {
+                    grinder.logger.error(">>> [DB 초기화 실패] HTTP 상태 코드: ${resetResponse.statusCode}")
+                }
+            } catch (Exception e) {
+                grinder.logger.error(">>> [DB 초기화 에러] 원인: ${e.message}")
+            }
+        }
+
+        // 모든 프로세스가 각자 소모한 시간 계산
+        long elapsed = System.currentTimeMillis() - beforeStartTime
+
+        // 목표 대기 시간(3초)에서 소모한 시간(DB 초기화 등)을 뺀 만큼만 정확히 마저 대기
+        long waitTime = 3000 - elapsed
+
+        if (waitTime > 0) {
+            grinder.logger.info(">>> [대기] 프로세스 ${grinder.processNumber} : 완벽한 동시 출발을 위해 ${waitTime}ms 대기 중...")
+            grinder.sleep(waitTime, 0)
+        }
+
+        // 매 프로세스 시작 시 실제 유입 카운트 배열 초기화
+        for (int i = 0; i < actualArrivals.length(); i++) {
+            actualArrivals.set(i, 0)
+        }
+
+        test.record(request)
+
+        // 프로세스별 학생 ID 할당
+        int totalProcesses = grinder.getProperties().getInt("grinder.processes", 1)
+        int usersPerProcess = TOTAL_USERS / totalProcesses
+
+        int startId = (grinder.processNumber * usersPerProcess) + 1
+        int endId = (grinder.processNumber + 1) * usersPerProcess
+
+        List<Integer> studentIds = (startId..endId).toList()
+        Collections.shuffle(studentIds) // 학생 ID 랜덤 섞기
+
+        studentIdQueue.clear()
+        studentIdQueue.addAll(studentIds)
+
+        grinder.logger.info(">>> [데이터 준비 완료] 프로세스 {} 학생 ID {} ~ {} (총 {}명) 큐 적재 완료",
+            grinder.processNumber, startId, endId, studentIds.size())
+    }
+
+    @Test
+    public void testEnrollmentBurst() {
+
+        // 지수 감쇠형 버스트 시뮬레이션
+        double u = ThreadLocalRandom.current().nextDouble()
+        double lambdaShape = 1.0
+        double maxTime = (double) TEST_DURATION_SECONDS
+
+        // 역함수 샘플링 공식을 통한 시간 계산
+        double timeInSec = -Math.log(1 - u * (1 - Math.exp(-lambdaShape * maxTime))) / lambdaShape
+        long randomDelay = (long) (timeInSec * 1000)
+
+        // [실제 유입 기록] 딜레이 시간을 초 단위로 환산하여 카운트 1 증가
+        int fireSecond = (int) (randomDelay / 1000)
+        if (fireSecond >= 0 && fireSecond < actualArrivals.length()) {
+            actualArrivals.incrementAndGet(fireSecond)
+        }
+
+        // 계산된 시간만큼 대기 후 발사
+        grinder.sleep(randomDelay, 0)
+
+        // 큐에서 무작위 학생 ID 추출
+        Integer studentId = studentIdQueue.poll()
+
+        if (studentId == null) {
+            grinder.logger.warn(">>> [테스트 경고] 이 프로세스에 할당된 학생 ID가 모두 소진되었습니다.")
+            return
+        }
+
+        long courseId = 1L
+
+        String payload = String.format("{\"studentId\": %d, \"courseId\": %d}", studentId, courseId)
+
+        // API POST 요청
+        HTTPResponse response = request.POST(targetUrl, payload.getBytes(), headers)
+
+        int statusCode = response.statusCode
+
+        // 검증 로직
+        if (statusCode == 200 || statusCode == 201) {
+            assertThat(statusCode, is(anyOf(equalTo(200), equalTo(201))))
+        } else if (statusCode == 400 || statusCode == 409) {
+            grinder.logger.info(">>> [비즈니스 예외] 정원 초과 [상태코드: ${statusCode}]")
+        } else {
+            grinder.logger.info(">>> [시스템 장애] 자원 고갈 [상태코드: ${statusCode}]]")
+            fail("동시성 제어 실패: HTTP ${statusCode}")
+        }
+    }
+
+    @AfterProcess
+    public static void afterProcess() {
+
+        // 테스트 종료 시 10초간의 실제 유입량을 리스트로 변환하여 출력
+        List<Integer> actualList = []
+        for (int i = 0; i < TEST_DURATION_SECONDS; i++) {
+            actualList.add(actualArrivals.get(i))
+        }
+
+        try {
+            // [동적 파일명 생성] 락 전략(STRATEGY), 인원수(TOTAL_USERS), 시작 시간(testStartTime) 조합
+            String fileName = String.format("/tmp/result/arrivals_%s_%d_%s.txt", STRATEGY, TOTAL_USERS, testStartTime)
+            File resultFile = new File(fileName)
+            
+            // 파일에 프로세스별 배열 기록
+            resultFile.append("Process " + grinder.processNumber + ": " + actualList.toString() + "\n")
+            
+        } catch (Exception e) {
+            // 무시
+        }
+    }
+}


### PR DESCRIPTION
## 📝 요약 (Summary)

ZooKeeper 기반 수강신청 API(`/v1/enrollments/zookeeper-lock`)의 처리량과 안정성을 측정하기 위한 nGrinder 테스트 스크립트(Groovy)를 추가했습니다. Vuser 200 규모의 웜업(Warm-up) 스크립트와 500, 800, 1000 규모의 본 테스트용 스크립트를 각각 세분화하여 작성했습니다. 특히 지수 감쇠(Exponential decay) 샘플링 모델을 적용하여 수강신청 오픈 직후의 폭발적인 버스트 트래픽(Burst Traffic)을 현실적으로 시뮬레이션했습니다.

## 🔗 관련 이슈 (Related Issue)

- Close #39 

## 🛠️ 주요 변경 사항 (Changes)

- [x] 기능 구현 / 설정 변경 내용
    - **테스트 스크립트 세분화:** `13ZooKeeperWarmUpTest` (200명), `14ZooKeeper500Test`, `15ZooKeeper800Test`, `16ZooKeeper1000Test` 스크립트 추가
    - **동시성 및 경합 제어:** 프로세스 간 완벽한 동시 출발 동기화 로직 및 테스트 시작 전 DB 자동 초기화 로직 구현
    - **동적 Payload 할당:** 프로세스별로 겹치지 않는 학생 ID 범위를 할당하고 랜덤하게 큐에서 추출하여 테스트 데이터 셋 구성
    - **버스트 트래픽 모델링:** 역함수 샘플링 공식을 활용하여 10초 내에 트래픽이 집중되었다가 감소하는 현실적인 부하 패턴 시뮬레이션 적용
    - **초당 도달률(Arrival Rate) 로깅:** 500, 800, 1000 Vuser 스크립트에 초당 실제 발생한 요청 수를 집계하여 `/tmp/result/` 경로에 파일로 저장하는 로직 추가 (추후 Python 분석용)
- [x] **테스트 코드 작성 여부**
    - 단일 및 Vuser 200 환경에서 스크립트 사전 실행을 통해 200 OK 응답 및 비즈니스 예외(정원 초과) 처리 등 정상 작동 여부 검증 완료

## 📊 실험 영향도 (Impact on Experiments)

- 단순한 균등 부하가 아닌 실제 수강신청과 매우 유사한 패턴의 버스트 트래픽을 ZooKeeper 락에 가해볼 수 있게 되었습니다.
- 각 테스트별 초당 도달률 데이터가 파일로 기록되므로, 향후 Python 파이프라인에서 TPS 및 지연 시간 분석 시 훨씬 더 정밀한 $2\sigma$ 안정성 평가 및 차트 도출이 가능해집니다.
- 최종 학위 논문 작성을 위한 벤치마크 테스트(Vuser 500/800/1000)를 수행할 준비가 완벽하게 마무리되었습니다.